### PR TITLE
UPDATE : Solved AC 티어 없을 때 공백 생기는 부분 수정

### DIFF
--- a/scripts/baekjoon/parse.js
+++ b/scripts/baekjoon/parse.js
@@ -70,11 +70,11 @@ function makeDetailMessageAndReadme(problem_info) {
     } = problem_info;
 
     const problem_tier_img = (level !== null && level !== undefined) ? `<img width=\"20px\"  src=\"https://d2gd6pc034wcta.cloudfront.net/tier/${level}.svg\" class=\"solvedac-tier\">` : '';
-    const bj_tier = (level !== null && level !== undefined) ? bj_level[level] : '';
+    const bj_tier = (level !== null && level !== undefined) ? bj_level[level]+' ' : '';
 
     const directory = `baekjoon/#${problemId} ${problem_title}`;
     const dirName = `#${problemId} ${problem_title}`;
-    const message = `[${bj_tier+' '}${problemId}] Title: ${problem_title}, Time: ${time} ms, Memory: ${memory} KB -NKLCBHub`;
+    const message = `[${bj_tier}${problemId}] Title: ${problem_title}, Time: ${time} ms, Memory: ${memory} KB -NKLCBHub`;
     const fileName = `${convertSingleCharToDoubleChar(problem_title)}.${languages[lang]}`;
 
     const readme = 


### PR DESCRIPTION
### Solved AC 미연동 시 공백 생기는 문제 해결

Solved AC 티어 보기 기능을 사용하지 않을 경우 문제 번호만 업로드 됨

문제 티어가 없을 때 공백만 남아서 문제 번호 앞에 빈 공백이 하나 생기는 문제가 발생

-> 티어 변수가 null이 아닐 때에만 공백을 추가하도록 하여 해결