### PR TITLE
[#7] [ Bug ] Github 미인증 상태에서 업로드를 요청했을 때 오류 처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NKLCB Hub
 
 
-![Release Version](https://img.shields.io/badge/release-0.0.4-yellow?style=flat-square)
+![Release Version](https://img.shields.io/badge/release-0.0.7-yellow?style=flat-square)
 ![Platform](https://img.shields.io/badge/platform-Chrome%20Extension-blue?style=flat-square)
 ![Last Commit](https://img.shields.io/github/last-commit/Donghyeon0915/NKLCB_Hub?style=flat-square)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "NKLCBHub(네카라쿠배 허브)",
     "description": "백준 온라인 저지(BOJ)의 문제를 Github에 쉽게 업로드할 수 있습니다.",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "manifest_version": 3,
     "permissions": [
         "tabs",

--- a/scripts/baekjoon/uploadFunctions.js
+++ b/scripts/baekjoon/uploadFunctions.js
@@ -13,6 +13,10 @@ async function uploadOneSolveProblemOnGit(bojData, cb) {
     const hook = await getHook();
     if (isNull(token) || isNull(hook)) {
         console.error('token or hook is null', token, hook);
+
+        const elem = document.getElementById('BaekjoonHub_progress_elem');
+        elem.className = 'markuploadfailed';
+        alert('Github 인증 토큰이 만료되었습니다. 재인증 후 다시 시도해주세요.');
         return;
     }
     return upload(token, hook, bojData.code, bojData.readme, bojData.directory, bojData.fileName, bojData.message, cb);


### PR DESCRIPTION
Github 미인증 상태에서 업로드를 요청했을 때 무한 로딩이 발생하는 현상 발생

Github 토큰을 검증하는 부분에서 Token이 null인 경우 alert와 실패 아이콘을 띄우도록 수정